### PR TITLE
Set output type to prevent additional tfm attribute generation

### DIFF
--- a/src/Forge/Forge.fsproj
+++ b/src/Forge/Forge.fsproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Forge.Core\Forge.Core.fsproj">


### PR DESCRIPTION
I was looking to get this working with core and to fix a possible issue with some proj file elements being lost for example add file operations
When I cloned I was unable to build using ```build.cmd``` as I got the following error

```
         --targetprofile:netcore
         --simpleresolution
         --nocopyfsharpcore
         obj\Release\netcoreapp2.1\Forge.AssemblyInfo.fs
         AssemblyInfo.fs
         Commands.fs
         Program.fs
         C:\Users\richa\AppData\Local\Temp\.NETCoreApp,Version=v2.1.AssemblyAttributes.fs
         
         
     1>C:\repos\Forge\src\Forge\Program.fs(67,5): error FS0433: A function labeled with the 'EntryPointAttribute' attribute must be the last declaration in the last file in the compilation sequence. [C:\repos\Forge\src\Forge\Forge.fsproj]
     1>Done Building Project "C:\repos\Forge\src\Forge\Forge.fsproj" (Rebuild target(s)) -- FAILED.
```
It looks like the additional AssemblyAttribute file (seen in list above) contains a target framework moniker attribute
Adding the OutputType element in the project file prevents this file from being generated

Also any reason why we shouldn't move to netcoreapp 2.2 ?

I'm building on windows with sdk 2.2.105